### PR TITLE
CSCQVAIN-123: Local dev login

### DIFF
--- a/cmd/qvain-backend/auth_api.go
+++ b/cmd/qvain-backend/auth_api.go
@@ -40,6 +40,8 @@ func NewAuthApi(config *Config, onLogin loginHook, logger zerolog.Logger) *AuthA
 		"https://"+config.Hostname+"/api/auth/cb",
 		config.oidcProviderUrl,
 		"/token",
+		oidc.WithAllowDevLogin(config.DevMode),
+		oidc.WithSkipExpiryCheck(config.DevMode),
 	)
 	if err != nil {
 		logger.Error().Err(err).Str("idp", config.oidcProviderName).Msg("oidc configuration failed")

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -21,9 +21,6 @@ const (
 
 	// DefaultCookiePath sets the URL path cookies from this package are valid for.
 	DefaultCookiePath = "/api/auth"
-
-	// skipRedirect dumps the token to the end-user's browser instead of redirecting back to the frontend.
-	skipRedirect = false
 )
 
 var ErrMissingCSCUserName = errors.New("Missing CSCUserName field")
@@ -158,12 +155,6 @@ func (client *OidcClient) Callback() http.HandlerFunc {
 
 		// client is now successfully logged in
 		client.logger.Info().Str("sub", idToken.Subject).Msg("login")
-
-		// debug response by dumping it to the browser instead of redirecting
-		if skipRedirect {
-			client.DumpToken(w, oauth2Token, idToken)
-			return
-		}
 
 		// OnLogin callback; don't write to the response before this as it might try to set a cookie
 		//if client.OnLogin != nil && client.OnLogin(w, r, idToken.Subject, oauth2Token.Expiry) != nil {


### PR DESCRIPTION
These changes make it possible to login using a custom token at /api/auth/login?token=[token] in development mode. This is not a complete offline solution because the back-end still needs to do OIDC discovery at startup. The custom token is verified against the configured OIDC provider, but is allowed to have expired.