### PR TITLE
CSCQVAIN-112: Qvain should not allow login if homeorganization is missing

### DIFF
--- a/cmd/qvain-backend/sessions.go
+++ b/cmd/qvain-backend/sessions.go
@@ -86,6 +86,11 @@ func MakeSessionHandlerForFairdata(mgr *sessions.Manager, db *psql.DB, onLogin l
 			identity = claims.CSCUserName
 		}
 
+		//user should have home organization
+		if claims.Org == "" {
+			return oidc.ErrMissingOrganization
+		}
+
 		uid, isNew, err := db.RegisterIdentity(svc, identity)
 		if err != nil {
 			return err

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -177,7 +177,7 @@ func (client *OidcClient) Callback() http.HandlerFunc {
 					return
 				}
 				if err == ErrMissingOrganization {
-					http.Redirect(w, r, client.frontendUrl+"?missingcscorg=1", http.StatusFound)
+					http.Redirect(w, r, client.frontendUrl+"?missingorg=1", http.StatusFound)
 					return
 				}
 

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -28,6 +28,9 @@ const (
 
 var ErrMissingCSCUserName = errors.New("Missing CSCUserName field")
 
+// User should have home organization
+var ErrMissingOrganization = errors.New("Missing Organization field")
+
 // OidcClient holds the OpenID Connect and OAuth2 configuration for an authentication provider.
 type OidcClient struct {
 	Name        string
@@ -171,6 +174,10 @@ func (client *OidcClient) Callback() http.HandlerFunc {
 			if err := client.OnLogin(w, r, oauth2Token, idToken); err != nil {
 				if err == ErrMissingCSCUserName {
 					http.Redirect(w, r, client.frontendUrl+"?missingcsc=1", http.StatusFound)
+					return
+				}
+				if err == ErrMissingOrganization {
+					http.Redirect(w, r, client.frontendUrl+"?missingcscorg=1", http.StatusFound)
 					return
 				}
 


### PR DESCRIPTION
CSCQVAIN-112: Add feature - Back-end changes for : Error should be thrown in case home organization is missing from user token