### PR TITLE
CSCQVAIN-141: Querying current session, session logout

### DIFF
--- a/cmd/qvain-backend/api.go
+++ b/cmd/qvain-backend/api.go
@@ -37,6 +37,7 @@ type Apis struct {
 	logger zerolog.Logger
 
 	datasets *DatasetApi
+	sessions *SessionApi
 	auth     *AuthApi
 	proxy    *ApiProxy
 	lookup   *LookupApi
@@ -54,6 +55,7 @@ func NewApis(config *Config) *Apis {
 		metax.WithInsecureCertificates(config.DevMode))
 
 	apis.datasets = NewDatasetApi(config.db, config.sessions, metax, config.NewLogger("datasets"))
+	apis.sessions = NewSessionApi(config.sessions, config.NewLogger("sessions"))
 	apis.auth = NewAuthApi(config, makeOnFairdataLogin(metax, config.db, config.NewLogger("sync")), config.NewLogger("auth"))
 	apis.proxy = NewApiProxy(
 		"https://"+config.MetaxApiHost+"/rest/",
@@ -76,6 +78,9 @@ func (apis *Apis) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "datasets/":
 		datasetsC.Add(1)
 		apis.datasets.ServeHTTP(w, r)
+	case "sessions/":
+		sessionsC.Add(1)
+		apis.sessions.ServeHTTP(w, r)
 	case "auth/":
 		authC.Add(1)
 		apis.auth.ServeHTTP(w, r)

--- a/cmd/qvain-backend/session_api.go
+++ b/cmd/qvain-backend/session_api.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/CSCfi/qvain-api/internal/sessions"
+	"github.com/francoispqt/gojay"
+	"github.com/rs/zerolog"
+)
+
+// SessionApi allows users to access their session information.
+type SessionApi struct {
+	sessions *sessions.Manager
+	logger   zerolog.Logger
+}
+
+// NewSessionApi creates a new SessionApi.
+func NewSessionApi(sessions *sessions.Manager, logger zerolog.Logger) *SessionApi {
+	return &SessionApi{sessions: sessions}
+}
+
+// Current dumps the (public) data from the current session in json format to the response.
+func (api *SessionApi) Current(w http.ResponseWriter, r *http.Request) {
+	session, err := api.sessions.SessionFromRequest(r)
+	if err != nil {
+		api.logger.Debug().Err(err).Msg("no current session")
+		jsonError(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return
+	}
+
+	enc := gojay.BorrowEncoder(w)
+	defer enc.Release()
+
+	apiWriteHeaders(w)
+	err = enc.EncodeObject(session.Public())
+	if err != nil {
+		api.logger.Error().Err(err).Msg("failed to encode public session")
+		jsonError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+}
+
+// Logout deletes the current user session and returns a json response.
+func (api *SessionApi) Logout(w http.ResponseWriter, r *http.Request) {
+	sid, err := sessions.GetSessionCookie(r)
+	if err != nil {
+		api.logger.Debug().Err(err).Msg("no current session")
+		jsonError(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return
+	}
+	success := api.sessions.DestroyWithCookie(w, sid)
+	if !success {
+		api.logger.Debug().Err(err).Msg("failed to destroy session")
+		jsonError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	apiWriteHeaders(w)
+	w.WriteHeader(http.StatusOK)
+
+	enc := gojay.BorrowEncoder(w)
+	defer enc.Release()
+
+	enc.AppendByte('{')
+	enc.AddStringKey("msg", "User logged out succesfully")
+	enc.AppendByte('}')
+	enc.Write()
+}
+
+// ServeHTTP satisfies the http.Handler interface; it is the main endpoint for the session api.
+func (api *SessionApi) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	api.logger.Debug().Str("path", r.URL.Path).Msg("request path")
+	head := ShiftUrlWithTrailing(r)
+
+	switch head {
+	case "":
+		switch r.Method {
+		case http.MethodGet:
+			api.Current(w, r)
+		case http.MethodOptions:
+			apiWriteOptions(w, "GET, OPTIONS")
+		default:
+			jsonError(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	case "logout":
+		switch r.Method {
+		case http.MethodPost:
+			api.Logout(w, r)
+		case http.MethodOptions:
+			apiWriteOptions(w, "POST, OPTIONS")
+		default:
+			jsonError(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	}
+}

--- a/cmd/qvain-backend/session_api.go
+++ b/cmd/qvain-backend/session_api.go
@@ -50,8 +50,8 @@ func (api *SessionApi) Logout(w http.ResponseWriter, r *http.Request) {
 	}
 	success := api.sessions.DestroyWithCookie(w, sid)
 	if !success {
-		api.logger.Debug().Err(err).Msg("failed to destroy session")
-		jsonError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		api.logger.Debug().Msg("failed to destroy session")
+		sessionError(w, sessions.ErrSessionNotFound)
 		return
 	}
 

--- a/cmd/qvain-backend/session_api.go
+++ b/cmd/qvain-backend/session_api.go
@@ -24,7 +24,7 @@ func (api *SessionApi) Current(w http.ResponseWriter, r *http.Request) {
 	session, err := api.sessions.SessionFromRequest(r)
 	if err != nil {
 		api.logger.Debug().Err(err).Msg("no current session")
-		jsonError(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		sessionError(w, sessions.ErrSessionNotFound)
 		return
 	}
 
@@ -44,8 +44,8 @@ func (api *SessionApi) Current(w http.ResponseWriter, r *http.Request) {
 func (api *SessionApi) Logout(w http.ResponseWriter, r *http.Request) {
 	sid, err := sessions.GetSessionCookie(r)
 	if err != nil {
-		api.logger.Debug().Err(err).Msg("no current session")
-		jsonError(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		api.logger.Debug().Err(err).Msg("no session cookie found")
+		sessionError(w, sessions.ErrSessionNotFound)
 		return
 	}
 	success := api.sessions.DestroyWithCookie(w, sid)


### PR DESCRIPTION
This brings back the session API that was originally removed as unused. I removed most of the functions and added a logout function that deletes the session.